### PR TITLE
Added styling to break lengthy input todo items strings

### DIFF
--- a/style.css
+++ b/style.css
@@ -32,6 +32,8 @@ body{
 
 .todo-items{
     margin-bottom: 30px;
+    overflow-wrap: break-word;
+    max-width: 500px;
 }
 
 .todo-item{


### PR DESCRIPTION
**Added:**
- Overflow-wrap css property to break lengthy strings in respective to its container.

![image](https://user-images.githubusercontent.com/42576354/133932433-9d2904f9-0b17-42ff-9182-b5b2911035e6.png)
